### PR TITLE
Look up for compiled .js in srcDir

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -11,7 +11,7 @@ export default function(source) {
   
   const nimFile = this.resourcePath
   const srcDir = path.dirname(nimFile)
-  const outDir = path.resolve(srcDir, 'nimcache')
+  const outDir = path.resolve(srcDir)
   const outFile = path.resolve(outDir, path.basename(nimFile, '.nim')) + '.js'
   const flags = opts.flags || []
 


### PR DESCRIPTION
NIm stopped compiling to nimcache some time ago. Now, compiled .js is placed in the same directory with the .nim file.